### PR TITLE
show event end time on schedule

### DIFF
--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -40,12 +40,8 @@ struct EventCell: View {
                             Text(dfu.hourMinuteTimeFormatter.string(from: event.beginTimestamp))
                                 .font(.subheadline)
                             if event.beginTimestamp != event.endTimestamp {
-                                Rectangle()
-                                    .fill(.tertiary)
-                                    .frame(width: 6, height: 1)
-                                    .padding(.vertical, 3)
                                 Text(dfu.hourMinuteTimeFormatter.string(from: event.endTimestamp))
-                                    .font(.subheadline)
+                                    .font(.caption2)
                             }
                         }
                         VStack(alignment: .leading, spacing: 3) {

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -31,13 +31,22 @@ struct EventCell: View {
                     .frame(width: 6)
                 HStack(alignment: .top) {
                     HStack(alignment: .center) {
-                        VStack {
+                        VStack(spacing: 0) {
                             if showDay {
                                 Text(dfu.monthDayFormatter.string(from: event.beginTimestamp))
                                     .font(.subheadline)
+                                    .padding(.bottom, 3)
                             }
                             Text(dfu.hourMinuteTimeFormatter.string(from: event.beginTimestamp))
                                 .font(.subheadline)
+                            if event.beginTimestamp != event.endTimestamp {
+                                Rectangle()
+                                    .fill(.tertiary)
+                                    .frame(width: 6, height: 1)
+                                    .padding(.vertical, 3)
+                                Text(dfu.hourMinuteTimeFormatter.string(from: event.endTimestamp))
+                                    .font(.subheadline)
+                            }
                         }
                         VStack(alignment: .leading, spacing: 3) {
                             Text(event.title).font(.headline)


### PR DESCRIPTION
At DEF CON this year I found it inconvenient to have to click into an event to see when it ends. I wanted to prioritize events like talks that lasts around an hour, over events like CTFs that last all day which I can go check out later. This PR adds the end times of the events in schedule.

I have also made PRs for this feature for the web and Android version: [PR for web](https://github.com/BeezleLabs/hackertracker-info/pull/1), [PR for Android](https://github.com/Advice-Dog/Schedule/pull/7).

## Before

|   |   |
|---|---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-08-19 at 18 23 47](https://github.com/BeezleLabs/hackertracker/assets/8357970/de8f6ef2-83ba-408a-b469-3dd157eb7095)| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-19 at 18 23 54](https://github.com/BeezleLabs/hackertracker/assets/8357970/fc463653-befc-4533-8edd-a286e33d4ab8) |

## After

|   |   |
|---|---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-08-19 at 20 54 32](https://github.com/BeezleLabs/hackertracker/assets/8357970/ba5777e2-acd0-4552-84e2-1e2e45dc8851)|![Simulator Screenshot - iPhone 14 Pro - 2023-08-19 at 20 54 08](https://github.com/BeezleLabs/hackertracker/assets/8357970/73de960b-f79a-4fcf-a911-2f561df218bc)|
